### PR TITLE
feat: make header visible for more elegant page layout

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -179,9 +179,13 @@ button, input, .suggested-item, .new-chat-button, .theme-toggle-button {
     transform: rotate(-180deg) scale(0.5);
 }
 
-/* Header - Hidden */
+/* Header */
 header {
-    display: none;
+    padding: 2rem 2rem 1.5rem;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border-color);
+    text-align: center;
+    flex-shrink: 0;
 }
 
 header h1 {


### PR DESCRIPTION
Fixes #2

This PR makes the existing header component visible to create a more elegant page layout as requested in the issue.

## Changes
- Removed `display: none` from header styles
- Added proper padding and styling to header
- Header now shows 'Course Materials Assistant' title and subtitle
- Maintains all existing functionality while improving visual design

Generated with [Claude Code](https://claude.ai/code)